### PR TITLE
FreeBSD support for openNDS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
           command: bash ./resources/build_libmicrohttpd.sh --compile
       - run:
           name: Build
-          command: make CFLAGS="-I/tmp/libmicrohttpd_install/include" LDFLAGS="-L/tmp/libmicrohttpd_install/lib" | tee buildlog.txt
+          command: make CFLAGS="-I/tmp/libmicrohttpd_install/include" LDFLAGS="-L/tmp/libmicrohttpd_install/lib" | tee buildlog.xml
       - store_test_results:
-          path: buildlog.txt
+          path: buildlog.xml
   deploy:
     docker:
       - image: cimg/base:stable

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 
+PLATFORM?=LINUX
+ifneq ($(OS),Windows_NT)
+PLATFORM=$(shell uname -s)
+endif
+
 CC?=gcc
 CFLAGS+=-O2 -g -Wall
 CFLAGS+=-Isrc
 #CFLAGS+=-Wall -Wwrite-strings -pedantic -std=gnu99
 LDFLAGS+=-pthread
-LDLIBS=-Wl,-Bstatic -lepoll-shim -lmicrohttpd -Wl,-Bdynamic -lgnutls -lpthread
+LDLIBS=-Wl,-Bstatic -lmicrohttpd
+ifeq ($(PLATFORM),FreeBSD)
+LDLIBS+=-lepoll-shim
+endif
+LDLIBS+=-Wl,-Bdynamic -lgnutls -lpthread
 
 STRIP=yes
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS+=-O2 -g -Wall
 CFLAGS+=-Isrc
 #CFLAGS+=-Wall -Wwrite-strings -pedantic -std=gnu99
 LDFLAGS+=-pthread
-LDLIBS=-lmicrohttpd -lpthread
+LDLIBS=-Wl,-Bstatic -lepoll-shim -lmicrohttpd -Wl,-Bdynamic -lgnutls -lpthread
 
 STRIP=yes
 
@@ -20,10 +20,10 @@ all: opennds ndsctl
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 opennds: $(NDS_OBJS) $(LIBHTTPD_OBJS)
-	$(CC) $(LDFLAGS) -o opennds $+ $(LDLIBS)
+	$(CC) $(LDFLAGS) -o opennds $(NDS_OBJS) $(LDLIBS)
 
 ndsctl: src/ndsctl.o
-	$(CC) $(LDFLAGS) -o ndsctl $+ $(LDLIBS)
+	$(CC) $(LDFLAGS) -o ndsctl src/ndsctl.o $(LDLIBS)
 
 clean:
 	rm -f opennds ndsctl src/*.o

--- a/src/conf.c
+++ b/src/conf.c
@@ -37,7 +37,13 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <arpa/inet.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/if_ether.h>
+#include <netinet/in.h>
+#else
 #include <netinet/ether.h>
+#endif
 
 #include "common.h"
 #include "safe.h"

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -26,7 +26,13 @@
 #include <stdint.h>
 #include <string.h>
 #include <pthread.h>
+#ifdef __FreeBSD__
+#include <limits.h>
+#include <sys/syslimits.h>
+#include <netinet/in.h>
+#else
 #include <linux/limits.h>
+#endif
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/src/http_microhttpd_utils.h
+++ b/src/http_microhttpd_utils.h
@@ -30,7 +30,6 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <alloca.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -35,6 +35,9 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#ifdef __FreeBSD__
+#include <sys/stat.h>
+#endif
 #include <fcntl.h>
 #include <unistd.h>
 #include <syslog.h>

--- a/src/util.c
+++ b/src/util.c
@@ -52,9 +52,14 @@
 #include <util.h>
 #endif
 
-#ifdef __linux__
+#if defined(__linux__)
 #include <netinet/in.h>
 #include <net/if.h>
+#endif
+
+#ifdef __FreeBSD__
+#include <signal.h>
+#include <sys/signal.h>
 #endif
 
 #include <string.h>


### PR DESCRIPTION
Code now compiles natively for FreeBSD.
Adds additional dependency on epoll-shim https://github.com/FreeBSDDesktop/epoll-shim
